### PR TITLE
Fix power down values

### DIFF
--- a/condenser/src/app/client_config.js
+++ b/condenser/src/app/client_config.js
@@ -9,14 +9,14 @@ export const APP_ICON = 'steem';
 // vars. client should read $STM_Config, server should read config package.
 export const APP_URL = 'https://steemit.com';
 export const APP_DOMAIN = 'steemit.com';
-export const LIQUID_TOKEN = 'Steem';
+export const LIQUID_TOKEN = 'EFTG';
 // sometimes it's impossible to use html tags to style coin name, hence usage of _UPPERCASE modifier
-export const LIQUID_TOKEN_UPPERCASE = 'STEEM';
-export const VESTING_TOKEN = 'STEEM POWER';
-export const INVEST_TOKEN_UPPERCASE = 'STEEM POWER';
+export const LIQUID_TOKEN_UPPERCASE = 'EFTG';
+export const VESTING_TOKEN = 'EFTG POWER';
+export const INVEST_TOKEN_UPPERCASE = 'EFTG POWER';
 export const INVEST_TOKEN_SHORT = 'SP';
-export const DEBT_TOKEN = 'STEEM DOLLAR';
-export const DEBT_TOKENS = 'STEEM DOLLARS';
+export const DEBT_TOKEN = 'EFTG DOLLAR';
+export const DEBT_TOKENS = 'EFTG DOLLARS';
 export const CURRENCY_SIGN = '$';
 export const WIKI_URL = ''; // https://wiki.golos.io/
 export const LANDING_PAGE_URL = 'https://steem.io/';
@@ -25,10 +25,10 @@ export const PRIVACY_POLICY_URL = 'https://' + APP_DOMAIN + '/privacy.html';
 export const WHITEPAPER_URL = 'https://steem.io/SteemWhitePaper.pdf';
 
 // these are dealing with asset types, not displaying to client, rather sending data over websocket
-export const LIQUID_TICKER = 'STEEM';
+export const LIQUID_TICKER = 'EFTG';
 export const VEST_TICKER = 'VESTS';
-export const DEBT_TICKER = 'SBD';
-export const DEBT_TOKEN_SHORT = 'SBD';
+export const DEBT_TICKER = 'EUR';
+export const DEBT_TOKEN_SHORT = 'EUR';
 
 // application settings
 export const DEFAULT_LANGUAGE = 'en'; // used on application internationalization bootstrap

--- a/condenser/src/app/utils/StateFunctions.js
+++ b/condenser/src/app/utils/StateFunctions.js
@@ -81,7 +81,7 @@ export function assetFloat(str, asset) {
         assert.equal(typeof str, 'string');
         assert.equal(typeof asset, 'string');
         assert(
-            new RegExp(`^\\d+(\\.\\d+)? ${asset}$`).test(str),
+            new RegExp('^\\d+(\\.\\d+)? [A-Z]+$').test(str),
             'Asset should be formatted like 99.99 ' + asset + ': ' + str
         );
         return parseFloat(str.split(' ')[0]);


### PR DESCRIPTION
This PR contains edit to ClientConfig that are necessary for custom chains. This file contains more Steem references that should be altered.

When the Power Down value was being formatted the RegEx was returning a null/no-match resulting in an erroneous result.