### PR TITLE
Specify jsonrpc version in request header for conveyor since Steemit KOA enforces this

### DIFF
--- a/condenser/src/app/utils/ServerApiClient.js
+++ b/condenser/src/app/utils/ServerApiClient.js
@@ -1,6 +1,7 @@
 import { api } from '@steemit/steem-js';
 
 const request_base = {
+    jsonrpc: '2.0',
     method: 'post',
     mode: 'no-cors',
     credentials: 'same-origin',


### PR DESCRIPTION
- set jsonrpc version 2.0 in conveyor json request 